### PR TITLE
通过豆瓣小组网页获取数据

### DIFF
--- a/douban_group_spy/const.py
+++ b/douban_group_spy/const.py
@@ -1,4 +1,5 @@
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
+DATE_FORMAT = '%Y-%m-%d'
 
 HREF_FORMAT = "<a href='{url}'>{url}</a>"
 IMG_FORMAT = '<img src="{url}" height="400" width="400" referrerpolicy ="never"/><br/>'

--- a/douban_group_spy/settings.py
+++ b/douban_group_spy/settings.py
@@ -120,7 +120,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-DOUBAN_BASE_HOST = 'https://api.douban.com'
+DOUBAN_BASE_HOST = 'https://www.douban.com'
 
-GROUP_TOPICS_BASE_URL = '{}/v2/group/{}/topics'
-GROUP_INFO_BASE_URL = '{}/v2/group/{}/'
+GROUP_TOPICS_BASE_URL = '{}/group/{}/discussion'
+GROUP_INFO_BASE_URL = '{}/group/{}/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,13 @@
-django==2.2.20
+beautifulsoup4==4.9.3
+certifi==2021.5.30
+charset-normalizer==2.0.2
+Click==7.0
+Django==2.2.20
+idna==3.2
 jsonfield==2.0.2
-click==7.0.0
-requests
+lxml==4.6.3
+pytz==2021.1
+requests==2.26.0
+soupsieve==2.2.1
+sqlparse==0.4.1
+urllib3==1.26.6


### PR DESCRIPTION
豆瓣 API 不能使用了，改成通过网页解析的方式来获取数据，有几个问题，

* 现在在列表上获取不到内容和创建时间，如果对每一个帖子都获取详情，感觉很容易被限制，所以暂时没有实现，如果你觉得可行，我会继续更新。
* 有些字段不知道在原来的接口上表示什么，不知道取值是否正确。