### PR TITLE
update crawler, fix #13, #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 为了方便，使用了 Django admin 进行数据的可视化。通过 Django admin 可对数据进行搜索，过滤等简单功能。
 
+由于豆瓣的限制，爬取每篇帖子都会随机等待 3~5 秒，以尽量不触及 Rate Limit，爬取速度比较慢，但能获取更多内容。
+
 ## 环境
 - python >= 3.6
 - sqlite
@@ -16,8 +18,9 @@
 1. 创建 venv `python3 -m venv venv`, 并激活 `. venv/bin/activate`
 2. 安装依赖 `pip install -r requirements.txt`
 3. 数据库初始化 `make migrate`
-4. 运行爬虫 eg: `python crawler_main.py -g 106955 -g baoanzufang -k 灵芝 -k 翻身 -e 求租` 
-5. 运行网页 `make run_server`, 默认账号密码均为 admin
+4. 修改配置，由于豆瓣的限制，你需要设置 Cookie 后才能开始爬取。在网页上登录豆瓣，将 `douban_group_spy/settings.py` 中的 `COOKIE` 配置修改为你的 Cookie
+5. 运行爬虫 eg: `python crawler_main.py -g 106955 -g baoanzufang -k 灵芝 -k 翻身 -e 求租`
+6. 运行网页 `make run_server`, 默认账号密码均为 admin
 
 ### 爬虫参数
 - `-g`: 要爬取小组的 id

--- a/douban_group_spy/const.py
+++ b/douban_group_spy/const.py
@@ -4,4 +4,4 @@ DATE_FORMAT = '%Y-%m-%d'
 HREF_FORMAT = "<a href='{url}'>{url}</a>"
 IMG_FORMAT = '<img src="{url}" height="400" width="400" referrerpolicy ="never"/><br/>'
 
-USER_AGENT = 'Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)'
+USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36'

--- a/douban_group_spy/settings.py
+++ b/douban_group_spy/settings.py
@@ -124,3 +124,5 @@ DOUBAN_BASE_HOST = 'https://www.douban.com'
 
 GROUP_TOPICS_BASE_URL = '{}/group/{}/discussion'
 GROUP_INFO_BASE_URL = '{}/group/{}/'
+
+COOKIE=''


### PR DESCRIPTION
1. 豆瓣更新了网页结构，导致有些元素获取不到报错，同步修改了。
2. 修改了 User-Agent，豆瓣对原来的 baidu 爬虫做了些限制，获取数据会异常。
3. 爬取帖子增加暂停时间，避免豆瓣的异常检查。
4. 增加 Cookie 配置，可以由用户设置 Cookie，获取更多数据。